### PR TITLE
Fix installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You can download the library as zip and call include Library -> zip library. Or 
 
 ```
 cd  ~/Documents/Arduino/libraries
-git clone pschatzmann/arduino-audio-tools.git
+git clone pschatzmann/arduino-libg7xx.git
 ```
 
 I recommend to use git because you can easily update to the latest version just by executing the ```git pull``` command in the project folder.


### PR DESCRIPTION
Change the git clone command from arduino-audio-tools to arduino-libg7xx